### PR TITLE
fix(maven): added mirrors to the central via nexus

### DIFF
--- a/images/maven/3.8.3-adoptopenjdk-15-v1-full-proxy/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15-v1-full-proxy/settings.xml
@@ -158,18 +158,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.3-adoptopenjdk-15-v1-full-proxy/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15-v1-full-proxy/settings.xml
@@ -130,6 +130,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -162,7 +167,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.3-adoptopenjdk-15-v1-proxy/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15-v1-proxy/settings.xml
@@ -158,18 +158,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.3-adoptopenjdk-15-v1-proxy/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15-v1-proxy/settings.xml
@@ -130,6 +130,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -162,7 +167,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.3-adoptopenjdk-15/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15/settings.xml
@@ -154,18 +154,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.3-adoptopenjdk-15/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15/settings.xml
@@ -131,6 +131,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -158,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-11-v1-proxy/settings.xml
+++ b/images/maven/3.8.5-openjdk-11-v1-proxy/settings.xml
@@ -131,6 +131,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -163,7 +168,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-11-v1-proxy/settings.xml
+++ b/images/maven/3.8.5-openjdk-11-v1-proxy/settings.xml
@@ -159,18 +159,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.5-openjdk-11/settings.xml
+++ b/images/maven/3.8.5-openjdk-11/settings.xml
@@ -154,18 +154,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.5-openjdk-11/settings.xml
+++ b/images/maven/3.8.5-openjdk-11/settings.xml
@@ -131,6 +131,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -158,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-17-v1-proxy/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v1-proxy/settings.xml
@@ -131,6 +131,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -163,7 +168,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-17-v1-proxy/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v1-proxy/settings.xml
@@ -159,18 +159,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.5-openjdk-17-v2/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v2/settings.xml
@@ -154,18 +154,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.5-openjdk-17-v2/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v2/settings.xml
@@ -131,6 +131,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -158,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-17-v3/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v3/settings.xml
@@ -131,6 +131,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -163,7 +168,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-17-v3/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v3/settings.xml
@@ -159,18 +159,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.5-openjdk-17/settings.xml
+++ b/images/maven/3.8.5-openjdk-17/settings.xml
@@ -155,18 +155,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.8.5-openjdk-17/settings.xml
+++ b/images/maven/3.8.5-openjdk-17/settings.xml
@@ -132,6 +132,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -159,7 +164,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.9.4-amazoncorretto-21-debian/settings.xml
+++ b/images/maven/3.9.4-amazoncorretto-21-debian/settings.xml
@@ -154,18 +154,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.9.4-amazoncorretto-21-debian/settings.xml
+++ b/images/maven/3.9.4-amazoncorretto-21-debian/settings.xml
@@ -131,6 +131,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -158,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.9.4-amazoncorretto-21/settings.xml
+++ b/images/maven/3.9.4-amazoncorretto-21/settings.xml
@@ -154,18 +154,12 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <!-- mirror
-     | Specifies a repository mirror site to use instead of a given repository. The repository that
-     | this mirror serves has an ID that matches the mirrorOf element of this mirror. IDs are used
-     | for inheritance and direct lookup purposes, and must be unique across the set of mirrors.
-     |
     <mirror>
-      <id>mirrorId</id>
-      <mirrorOf>repositoryId</mirrorOf>
-      <name>Human Readable Name for this Mirror.</name>
-      <url>http://my.repository.com/repo/path</url>
+      <id>mirror</id>
+      <mirrorOf>central</mirrorOf>
+      <name>Maven Central DayMarket repo.</name>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
     </mirror>
-     -->
   </mirrors>
 
   <!-- profiles

--- a/images/maven/3.9.4-amazoncorretto-21/settings.xml
+++ b/images/maven/3.9.4-amazoncorretto-21/settings.xml
@@ -131,6 +131,11 @@ under the License.
     </server>
     -->
     <server>
+      <id>mirror</id>
+      <username>${env.SERVER_USERNAME}</username>
+      <password>${env.SERVER_PASSWORD}</password>
+    </server>
+    <server>
       <id>um-repo-releases</id>
       <username>${env.SERVER_USERNAME}</username>
       <password>${env.SERVER_PASSWORD}</password>
@@ -158,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-public/</url>
+      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 


### PR DESCRIPTION
Хочу во все Maven пайплайны добавить настройку, чтобы central проксировался через наш Nexus, таким образом можно будет скачивать зависимости не по публичной сети, которая иногда работает 50Kb/sec, а по гигабитной внутри инфры узума.

Проверил локально, зависимости, которые есть в зеркале, тянутся оттуда, новые там почему-то не появились, смотрю

Jira: MAI-189