### PR TITLE
fix(maven): using internal ingress for maven

### DIFF
--- a/images/maven/3.8.3-adoptopenjdk-15-v1-full-proxy/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15-v1-full-proxy/settings.xml
@@ -167,7 +167,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.3-adoptopenjdk-15-v1-proxy/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15-v1-proxy/settings.xml
@@ -167,7 +167,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.3-adoptopenjdk-15/settings.xml
+++ b/images/maven/3.8.3-adoptopenjdk-15/settings.xml
@@ -163,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-11-v1-proxy/settings.xml
+++ b/images/maven/3.8.5-openjdk-11-v1-proxy/settings.xml
@@ -168,7 +168,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-11/settings.xml
+++ b/images/maven/3.8.5-openjdk-11/settings.xml
@@ -163,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-17-v1-proxy/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v1-proxy/settings.xml
@@ -168,7 +168,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-17-v2/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v2/settings.xml
@@ -163,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-17-v3/settings.xml
+++ b/images/maven/3.8.5-openjdk-17-v3/settings.xml
@@ -168,7 +168,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.8.5-openjdk-17/settings.xml
+++ b/images/maven/3.8.5-openjdk-17/settings.xml
@@ -164,7 +164,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.9.4-amazoncorretto-21-debian/settings.xml
+++ b/images/maven/3.9.4-amazoncorretto-21-debian/settings.xml
@@ -163,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 

--- a/images/maven/3.9.4-amazoncorretto-21/settings.xml
+++ b/images/maven/3.9.4-amazoncorretto-21/settings.xml
@@ -163,7 +163,7 @@ under the License.
       <id>mirror</id>
       <mirrorOf>central</mirrorOf>
       <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.cluster.daymarket.uz/repository/maven-central/</url>
+      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
     </mirror>
   </mirrors>
 


### PR DESCRIPTION
Jira: MAI-189

внутри VPN билд работает, снаружи я не проверял, если подразумевается, что эти образы используются только внутри VPN, то должно быть ок

```
gasabr@nixos ~/Projects/work/infra-docker (MAI-189_trying_internal_ingress) 
❯ cd images/maven/3.8.5-openjdk-11/
gasabr@nixos ~/Projects/work/infra-docker/images/maven/3.8.5-openjdk-11 (MAI-189_trying_internal_ingress) 
❯ docker build . -t maven:local
Sending build context to Docker daemon  13.82kB
Step 1/2 : FROM maven:3.8.5-openjdk-11
 ---> 96e051c66256
Step 2/2 : COPY settings.xml /usr/share/maven/conf/
 ---> 6e54e5c1474c
Successfully built 6e54e5c1474c
Successfully tagged maven:local
gasabr@nixos ~/Projects/work/infra-docker/images/maven/3.8.5-openjdk-11 (MAI-189_trying_internal_ingress) 
❯ cd ~/work/clickstream/
gasabr@nixos ~/work/clickstream (DSE-1046_sessions_via_redis) 
❯ docker run --rm -it -e SERVER_USERNAME=gleb_abroskin -e SERVER_PASSWORD=XXXX -w /app --network=host -v (pwd):/app maven:local bash
root@nixos:/app# mvn test -pl common
[INFO] Scanning for projects...
Downloading from um-repo-releases: https://nexus.infra.cluster.daymarket.uz/repository/maven-releases/org/springframework/boot/spring-boot-starter-parent/2.7.3/spring-boot-starter-parent-2.7.3.pom
Downloading from confluent: https://packages.confluent.io/maven/org/springframework/boot/spring-boot-starter-parent/2.7.3/spring-boot-starter-parent-2.7.3.pom
Downloading from spring-milestones: https://repo.spring.io/milestone/org/springframework/boot/spring-boot-starter-parent/2.7.3/spring-boot-starter-parent-2.7.3.pom
Downloading from mirror: https://nexus.infra.internal.daymarket.uz/repository/maven-central/org/springframework/boot/spring-boot-starter-parent/2.7.3/spring-boot-starter-parent-2.7.3.pom
Downloaded from mirror: https://nexus.infra.internal.daymarket.uz/repository/maven-central/org/springframework/boot/spring-boot-starter-parent/2.7.3/spring-boot-starter-parent-2.7.3.pom (9.2 kB at 25 kB/s)

```