### PR TITLE
fix(maven:openjdk:17): remove mirrors from settings.xml

### DIFF
--- a/images/maven/3-openjdk-17-proxy/settings.xml
+++ b/images/maven/3-openjdk-17-proxy/settings.xml
@@ -169,12 +169,6 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <mirror>
-      <id>mirror</id>
-      <mirrorOf>central</mirrorOf>
-      <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
-    </mirror>
   </mirrors>
 
   <!-- profiles


### PR DESCRIPTION
Удалил зеркало централа для maven:openjdk:17-proxy