### PR TITLE
fix(maven:openjdk:17): remove mirrors from settings.xml

### DIFF
--- a/images/maven/3-openjdk-17-proxy/settings.xml
+++ b/images/maven/3-openjdk-17-proxy/settings.xml
@@ -159,12 +159,6 @@ under the License.
    | server for that repository.
    |-->
   <mirrors>
-    <mirror>
-      <id>mirror</id>
-      <mirrorOf>central</mirrorOf>
-      <name>Maven Central DayMarket repo.</name>
-      <url>https://nexus.infra.internal.daymarket.uz/repository/maven-central/</url>
-    </mirror>
   </mirrors>
 
   <!-- profiles


### PR DESCRIPTION
Этот образ я отдельно заводил для своих сервисов. Когда-то давно я намеренно удалил зеркала (см. коммит 312f70de10e9c6896fbaf2cb3a08589301ed415a), но какой-то нехороший человек их зачем-то сюда добавил и приложение перестало собираться,