### PR TITLE
feat(images:data-platform-docs): add v0.1.0 image

### DIFF
--- a/images/data-platform-docs/v0.1.0/Dockerfile
+++ b/images/data-platform-docs/v0.1.0/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim AS builder
+
+ARG DOCS_REF=v0.1.0
+
+WORKDIR /build
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git clone --depth 1 --branch "$DOCS_REF" https://github.com/DayMarket/data-platform-docs.git .
+
+RUN pip install --no-cache-dir -r requirements.txt \
+    && mkdocs build --strict
+
+FROM nginx:alpine
+
+COPY --from=builder /build/site/ /usr/share/nginx/html/
+
+EXPOSE 80


### PR DESCRIPTION
## Summary

- Adds `images/data-platform-docs/v0.1.0/Dockerfile` — multi-stage build that clones the `data-platform-docs` repo at `DOCS_REF=v0.1.0`, runs `mkdocs build --strict`, and serves the static site from `nginx:alpine`.
- Enables publishing `ghcr.io/daymarket/data-platform-docs:v0.1.0` the next time infra-docker is tagged.

Part of the three-PR bootstrap for the internal docs site at `data-platform-docs.internal.daymarket.uz`. Content repo: https://github.com/DayMarket/data-platform-docs (already pushed, awaiting `v0.1.0` tag).

## Test plan

- [ ] `hadolint images/data-platform-docs/v0.1.0/Dockerfile` passes (the PR workflow runs this).
- [ ] The PR workflow's `build-image` job successfully builds the image without pushing.
- [ ] After merge + a new infra-docker tag, `ghcr.io/daymarket/data-platform-docs:v0.1.0` is listed in the org Packages.
- [ ] Image runs locally: `docker run --rm -p 8080:80 ghcr.io/daymarket/data-platform-docs:v0.1.0` → `curl -fsSL http://localhost:8080/` returns HTML with "Uzum Data Platform Docs".

## Related

- Chart PR in infra-helm: `charts/data-platform-docs` (new).
- ArgoCD PR in infra-argocd: `prod-data/data-apps/data-platform-docs/` (new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)